### PR TITLE
Remove irritating exit

### DIFF
--- a/autoload/agit/view/log.vim
+++ b/autoload/agit/view/log.vim
@@ -98,10 +98,6 @@ function! s:log.setlocal()
     autocmd CursorHold <buffer> if g:agit_enable_auto_show_commit | call s:show_commit() | endif
     autocmd BufLeave <buffer> if g:agit_enable_auto_show_commit | call s:cleanup() | endif
 
-    if exists('##QuitPre')
-      autocmd QuitPre <buffer> call s:exit()
-    endif
-
     autocmd BufEnter <buffer> if g:agit_enable_auto_refresh | call agit#reload() | endif
 
     autocmd ShellCmdPost <buffer> call agit#reload()
@@ -124,13 +120,6 @@ function! s:log.setlocal()
 
   function! s:cleanup()
     let &updatetime = s:save_ut
-  endfunction
-
-  function! s:exit()
-    if !exists('t:agit_git')
-      return
-    endif
-    silent! only!
   endfunction
 
   function! s:skip_empty_line()


### PR DESCRIPTION
It was quite irritating that the autocmd tried to close all the windows
generated by agit.

Typical problematic cases are below:
- `:tabonly` at another tab.
- `:tabclose` at the agit tab.
- `:only` at the agit tab to concentrate an agit buffer.